### PR TITLE
Update install-local.sh

### DIFF
--- a/bbb-libreoffice/install-local.sh
+++ b/bbb-libreoffice/install-local.sh
@@ -48,6 +48,7 @@ FILE_SUDOERS_CHECK=`[ -f /etc/sudoers.d/zzz-bbb-docker-libreoffice ] && echo 1 |
 if [ "$FILE_SUDOERS_CHECK" = "0" ]; then
 	echo "Sudoers file doesn't exists, installing"
 	cp assets/zzz-bbb-docker-libreoffice /etc/sudoers.d/zzz-bbb-docker-libreoffice
+	chmod 0440 /etc/sudoers.d/zzz-bbb-docker-libreoffice
 else
 	echo "Sudoers file already exists"
 fi;


### PR DESCRIPTION
correct permissions  for files in /etc/sudoers.d/

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

`man sudoers` says: _The sudoers file must not be world-writable, the default file mode is 0440 […]_

### Motivation

Avoid warnings from visudo because of wrong permissions. (Additionally, the Puppet module saz/sudo fails when using wrong permissions.)

### More

